### PR TITLE
This renaming one was still on some lost branch @ bitbucket...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.appfoundry.promtius</groupId>
     <artifactId>promtius-parent</artifactId>
-    <version>2.0</version>
+    <version>3.0</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/promtius-api/pom.xml
+++ b/promtius-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>be.appfoundry.promtius</groupId>
         <artifactId>promtius-parent</artifactId>
-        <version>2.0</version>
+        <version>3.0</version>
     </parent>
 
     <artifactId>promtius-api</artifactId>

--- a/promtius-api/src/main/java/be/appfoundry/promtius/ClientTokenService.java
+++ b/promtius-api/src/main/java/be/appfoundry/promtius/ClientTokenService.java
@@ -13,17 +13,22 @@ import java.util.List;
  * @author Mike Seghers
  */
 public interface ClientTokenService<CT extends ClientToken<T, P>, T, P, G> {
+
     /**
-     * searches client tokens for a given platform.
+     * Searches client tokens for a given platform.
      */
-    List<CT> findClientTokensForOperatingSystem(P platform);
+    List<CT> findClientTokensForPlatform(P platform);
+
+    /**
+     * Searches client tokens for a given platform and groups.
+     */
+    List<CT> findClientTokensForPlatform(P platform, Collection<G> groups);
 
     /**
      * Unregister a client token.
      */
     void unregisterClientToken(CT clientToken);
 
-    List<CT> findClientTokensForOperatingSystem(P platform, Collection<G> groups);
 
     /**
      * Replace the existing token's token value with the given token value.

--- a/promtius-apns/pom.xml
+++ b/promtius-apns/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>be.appfoundry.promtius</groupId>
         <artifactId>promtius-parent</artifactId>
-        <version>2.0</version>
+        <version>3.0</version>
     </parent>
 
     <artifactId>promtius-apns</artifactId>

--- a/promtius-apns/src/main/java/be/appfoundry/promtius/apple/ApplePushNotificationServicePusher.java
+++ b/promtius-apns/src/main/java/be/appfoundry/promtius/apple/ApplePushNotificationServicePusher.java
@@ -49,7 +49,7 @@ public class ApplePushNotificationServicePusher<CT extends ClientToken<String, P
     public void sendPush(final PushPayload payload) {
         LOGGER.info("Sending payload ({}) to APNs", payload);
         unregisterInactiveDevices();
-        pushPayloadToClientsIdentifiedByTokens(payload, clientTokenService.findClientTokensForOperatingSystem(platform));
+        pushPayloadToClientsIdentifiedByTokens(payload, clientTokenService.findClientTokensForPlatform(platform));
         LOGGER.info("APNs push finished", payload);
     }
 
@@ -58,7 +58,7 @@ public class ApplePushNotificationServicePusher<CT extends ClientToken<String, P
         LOGGER.info("Sending payload ({}) to APNs", payload);
         unregisterInactiveDevices();
         LOGGER.debug("Inactive devices unregistered - starting actual push now");
-        pushPayloadToClientsIdentifiedByTokens(payload, clientTokenService.findClientTokensForOperatingSystem(platform, groups));
+        pushPayloadToClientsIdentifiedByTokens(payload, clientTokenService.findClientTokensForPlatform(platform, groups));
         LOGGER.info("APNs push finished", payload);
     }
 

--- a/promtius-apns/src/test/java/be/appfoundry/promtius/apple/ApplePushNotificationServicePusherTest.java
+++ b/promtius-apns/src/test/java/be/appfoundry/promtius/apple/ApplePushNotificationServicePusherTest.java
@@ -70,7 +70,7 @@ public class ApplePushNotificationServicePusherTest {
     public void test_sendPush() throws Exception {
         PushPayload payload = new PushPayload.Builder().withMessage("message").withSound("sound").build();
         List<TestClientToken> tokens = Arrays.asList(tokenA, tokenB);
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
 
         pusher.sendPush(payload);
 
@@ -84,7 +84,7 @@ public class ApplePushNotificationServicePusherTest {
         map.put("custom", innerMap);
         PushPayload payload = new PushPayload.Builder().withMessage("message").withCustomFields(map).build();
         List<TestClientToken> tokens = Arrays.asList(tokenA, tokenB);
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
 
         pusher.sendPush(payload);
 
@@ -95,7 +95,7 @@ public class ApplePushNotificationServicePusherTest {
     public void test_sendPush_considersTTL() throws Exception {
         PushPayload payload = new PushPayload.Builder().withMessage("message").withTimeToLive(10).build();
         List<TestClientToken> tokens = Arrays.asList(tokenA, tokenB);
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
 
         pusher.sendPush(payload);
 
@@ -108,7 +108,7 @@ public class ApplePushNotificationServicePusherTest {
         PushPayload payload = new PushPayload.Builder().withMessage("message").build();
         List<TestClientToken> tokens = Arrays.asList(tokenA, tokenB);
         final Collection<String> groups = Arrays.asList("groupA", "groupB");
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM, groups)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM, groups)).thenReturn(tokens);
 
         pusher.sendPush(payload, groups);
 
@@ -142,7 +142,7 @@ public class ApplePushNotificationServicePusherTest {
     @Test
     public void test_whenUnregistrationFails_pushStillContinues() throws Exception {
         List<TestClientToken> tokens = Arrays.asList(tokenA, tokenB);
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
         when(apnsService.getInactiveDevices()).thenThrow(new RuntimeException());
         PushPayload payload = new PushPayload.Builder().withMessage("message").build();
         pusher.sendPush(payload);

--- a/promtius-gcm/pom.xml
+++ b/promtius-gcm/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>be.appfoundry.promtius</groupId>
         <artifactId>promtius-parent</artifactId>
-        <version>2.0</version>
+        <version>3.0</version>
     </parent>
 
     <artifactId>promtius-gcm</artifactId>

--- a/promtius-gcm/src/main/java/be/appfoundry/promtius/google/GoogleCloudMessagingPusher.java
+++ b/promtius-gcm/src/main/java/be/appfoundry/promtius/google/GoogleCloudMessagingPusher.java
@@ -48,7 +48,7 @@ public final class GoogleCloudMessagingPusher<CT extends ClientToken<String, P>,
     @Override
     public void sendPush(final PushPayload payload) {
         LOGGER.info("Sending payload ({}) to GCM", payload);
-        List<CT> tokens = clientTokenService.findClientTokensForOperatingSystem(platform);
+        List<CT> tokens = clientTokenService.findClientTokensForPlatform(platform);
         pushPayloadToClientsIdentifiedByTokens(payload, tokens);
         LOGGER.info("GCM push finished", payload);
     }
@@ -56,7 +56,7 @@ public final class GoogleCloudMessagingPusher<CT extends ClientToken<String, P>,
     @Override
     public void sendPush(final PushPayload payload, final Collection<G> groups) {
         LOGGER.info("Sending payload ({}) to groups {}", payload, groups);
-        List<CT> tokens = clientTokenService.findClientTokensForOperatingSystem(platform, groups);
+        List<CT> tokens = clientTokenService.findClientTokensForPlatform(platform, groups);
         pushPayloadToClientsIdentifiedByTokens(payload, tokens);
         LOGGER.info("GCM group push finished", payload);
     }

--- a/promtius-gcm/src/test/java/be/appfoundry/promtius/google/GoogleCloudMessagingPusherTest.java
+++ b/promtius-gcm/src/test/java/be/appfoundry/promtius/google/GoogleCloudMessagingPusherTest.java
@@ -83,7 +83,7 @@ public class GoogleCloudMessagingPusherTest {
     public void test_sendPush() throws Exception {
         PushPayload payload = new PushPayload.Builder().withMessage("message").withSound("sound").build();
         List<ClientToken<String, String>> tokens = Arrays.asList(tokenA, tokenB);
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
         when(tokenA.getToken()).thenReturn("token1");
         when(tokenB.getToken()).thenReturn("token2");
         pusher.sendPush(payload);
@@ -104,11 +104,11 @@ public class GoogleCloudMessagingPusherTest {
     @Test
     public void test_sendPushToGroup() throws Exception {
         List<ClientToken<String, String>> tokens = Arrays.asList(tokenA, tokenB);
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
         when(tokenA.getToken()).thenReturn("token1");
         when(tokenB.getToken()).thenReturn("token2");
         final Collection<String> groups = Arrays.asList("groupA", "groupB");
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM, groups)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM, groups)).thenReturn(tokens);
 
         pusher.sendPush(payload, groups);
 
@@ -133,7 +133,7 @@ public class GoogleCloudMessagingPusherTest {
         map.put("custom", innerMap);
         PushPayload payload = new PushPayload.Builder().withMessage("message").withCustomFields(map).build();
 
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
         pusher.sendPush(payload);
 
         ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
@@ -146,7 +146,7 @@ public class GoogleCloudMessagingPusherTest {
     @Test
     public void test_sendPush_considersTTL() throws Exception {
         final List<ClientToken<String, String>> tokens = Arrays.asList(tokenA, tokenB);
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
         PushPayload payload = new PushPayload.Builder().withMessage("message").withTimeToLive(10).build();
         pusher.sendPush(payload);
 
@@ -160,7 +160,7 @@ public class GoogleCloudMessagingPusherTest {
     @Test
     public void test_sendPush_setDiscrimimatorAsCollapseKey() throws Exception {
         final List<ClientToken<String, String>> tokens = Arrays.asList(tokenA, tokenB);
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
         pusher.sendPush(payload);
 
 
@@ -174,7 +174,7 @@ public class GoogleCloudMessagingPusherTest {
     public void test_sendPush_onIOException() throws Exception {
         PushPayload payload = new PushPayload.Builder().withMessage("message").build();
         List<ClientToken<String, String>> tokens = Arrays.asList(tokenA, tokenB);
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
         when(wrapper.send(Mockito.any(Message.class), anyListOf(String.class), anyInt())).thenThrow(new IOException());
 
         pusher.sendPush(payload);
@@ -187,7 +187,7 @@ public class GoogleCloudMessagingPusherTest {
             tokens.add(tokenA);
         }
         when(tokenA.getToken()).thenReturn("token");
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
 
         pusher.sendPush(payload);
 
@@ -207,7 +207,7 @@ public class GoogleCloudMessagingPusherTest {
         MulticastResult expected = getMulticastResultBuilder(50, 50, 20, 1, results);
 
         when(tokenA.getToken()).thenReturn("oldToken");
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
         when(wrapper.send(Mockito.any(Message.class), anyListOf(String.class), anyInt())).thenReturn(expected);
         when(clientTokenFactory.createClientToken("oldToken", TEST_PLATFORM)).thenReturn(tokenB);
         when(clientTokenFactory.createClientToken("newToken", TEST_PLATFORM)).thenReturn(tokenA);
@@ -224,7 +224,7 @@ public class GoogleCloudMessagingPusherTest {
         MulticastResult expected = getMulticastResultBuilder(50, 50, 20, 1, results);
 
         when(tokenA.getToken()).thenReturn("oldToken");
-        when(clientTokenService.findClientTokensForOperatingSystem(TEST_PLATFORM)).thenReturn(tokens);
+        when(clientTokenService.findClientTokensForPlatform(TEST_PLATFORM)).thenReturn(tokens);
         when(wrapper.send(Mockito.any(Message.class), anyListOf(String.class), anyInt())).thenReturn(expected);
         when(clientTokenFactory.createClientToken("oldToken", TEST_PLATFORM)).thenReturn(tokenB);
 


### PR DESCRIPTION
ClientTokenService:: findClientTokensForOperatingSystem(Platform P)  ->  findClientTokensForPlatform(Platform P)
Semantic versioning (http://semver.org/) dictates a major version increment upon incompatible API changes, hence the version number is upped to 3.0

Don't know whether this should go in...???
